### PR TITLE
Add Cache-Control and Expires headers to combo responses.

### DIFF
--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -17,6 +17,8 @@ var fs   = require('fs'),
 exports.combine = function (config) {
   var mimeTypes = config.mimeTypes || MIME_TYPES,
 
+      maxAge = config.maxAge || 31536000000, // one year in milliseconds
+
       // Intentionally using the sync method because this only runs when the
       // middleware is initialized, and we want it to throw if there's an error.
       rootPath = fs.realpathSync(config.rootPath);
@@ -36,6 +38,10 @@ exports.combine = function (config) {
       if (lastModified) {
         res.header('Last-Modified', lastModified.toUTCString());
       }
+
+      // http://code.google.com/speed/page-speed/docs/caching.html
+      res.header('Cache-Control', 'public, max-age=' + (maxAge / 1000));
+      res.header('Expires', new Date(Date.now() + maxAge).toUTCString());
 
       res.header('Content-Type', (type || 'text/plain') + ';charset=utf-8');
       res.body = body.join('\n');


### PR DESCRIPTION
This is handy when developing on localhost, and also when the reverse proxy/caching layer does not set them (merely passing through what is already set).
