### PR TITLE
Describe BadRequest errors better

### DIFF
--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -45,7 +45,7 @@ exports.combine = function (config) {
 
     if (!pending) {
       // No files requested.
-      return next(new BadRequest);
+      return next(new BadRequest('No files requested.'));
     }
 
     query.forEach(function (relativePath, i) {
@@ -59,11 +59,11 @@ exports.combine = function (config) {
         // Bubble up an error if the file can't be found or if the request
         // attempts to traverse above the root path.
         if (err || !absolutePath || absolutePath.indexOf(rootPath) !== 0) {
-          return next(new BadRequest);
+          return next(new BadRequest('File not found in root path: ' + relativePath));
         }
 
         fs.stat(absolutePath, function (err, stats) {
-          if (err || !stats.isFile()) { return next(new BadRequest); }
+          if (err || !stats.isFile()) { return next(new BadRequest('File does not exist: ' + relativePath)); }
 
           var mtime = new Date(stats.mtime);
 
@@ -72,7 +72,7 @@ exports.combine = function (config) {
           }
 
           fs.readFile(absolutePath, 'utf8', function (err, data) {
-            if (err) { return next(new BadRequest); }
+            if (err) { return next(new BadRequest('Error reading file: ' + relativePath)); }
 
             body[i]  = data;
             pending -= 1;
@@ -91,8 +91,9 @@ exports.combine = function (config) {
 // requested file can't be found (a NotFound error wouldn't be appropriate in
 // that case since the route itself exists; it's the request that's at fault).
 function BadRequest(message) {
+  Error.call(this);
   this.name = 'BadRequest';
-  Error.call(this, message || 'Bad request.');
+  this.message = message;
   Error.captureStackTrace(this, arguments.callee);
 }
 util.inherits(BadRequest, Error);

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,7 @@ module.exports = function (config, baseApp) {
 
     app.error(function (err, req, res, next) {
       if (err instanceof combo.BadRequest) {
-        res.send('Bad request.', {'Content-Type': 'text/plain'}, 400);
+        res.send('Bad request. ' + err.message, {'Content-Type': 'text/plain'}, 400);
       } else {
         next();
       }


### PR DESCRIPTION
Mostly a debugging tool, useful for distinguishing what particular bit got wedged in the request. The filesystem paths are never exposed, merely the chunk already visible in the querystring.
