### PR TITLE
Stricter, up-front MIME type filtering.

### DIFF
--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -27,15 +27,13 @@ exports.combine = function (config) {
         maxAge = 31536000; // one year in seconds
     }
 
-    function getMimeType(filename) {
-        return mimeTypes[path.extname(filename).toLowerCase()];
-    }
-
     return function (req, res, next) {
         var body    = [],
             query   = parseQuery(req.url),
             pending = query.length,
-            type    = pending && getMimeType(query[0]),
+            fileTypes = getFileTypes(query),
+            // fileTypes array should always have one member, else error
+            type    = fileTypes.length === 1 && mimeTypes[fileTypes[0]],
             lastModified;
 
         function finish() {
@@ -58,6 +56,22 @@ exports.combine = function (config) {
         if (!pending) {
             // No files requested.
             return next(new BadRequest('No files requested.'));
+        }
+
+        if (!type) {
+            if (fileTypes.indexOf('') > -1) {
+                // Most likely a malformed URL, which will just cause
+                // an exception later. Short-cut to the inevitable conclusion.
+                return next(new BadRequest('Truncated query parameters.'));
+            }
+            else if (fileTypes.length === 1) {
+                // unmapped type found
+                return next(new BadRequest('Illegal MIME type present.'));
+            }
+            else {
+                // A request may only have one MIME type
+                return next(new BadRequest('Only one MIME type allowed per request.'));
+            }
         }
 
         query.forEach(function (relativePath, i) {
@@ -116,6 +130,44 @@ exports.BadRequest = BadRequest; // exported to allow instanceof checks
 // -- Private Methods ----------------------------------------------------------
 function decode(string) {
     return decodeURIComponent(string).replace(/\+/g, ' ');
+}
+
+/**
+Dedupes an array of strings, returning an array that's guaranteed to contain
+only one copy of a given string.
+
+This method differs from `Array.unique()` in that it's optimized for use only
+with strings, whereas `unique` may be used with other types (but is slower).
+Using `dedupe()` with non-string values may result in unexpected behavior.
+
+@method dedupe
+@param {String[]} array Array of strings to dedupe.
+@return {Array} Deduped copy of _array_.
+**/
+function dedupe(array) {
+    var hash    = {},
+        results = [],
+        hasOwn  = Object.prototype.hasOwnProperty,
+        i, item, len;
+
+    for (i = 0, len = array.length; i < len; i += 1) {
+        item = array[i];
+
+        if (!hasOwn.call(hash, item)) {
+            hash[item] = 1;
+            results.push(item);
+        }
+    }
+
+    return results;
+}
+
+function getExtName(filename) {
+    return path.extname(filename).toLowerCase();
+}
+
+function getFileTypes(files) {
+    return dedupe(files.map(getExtName));
 }
 
 // Because querystring.parse() is silly and tries to be too clever.

--- a/test/server.js
+++ b/test/server.js
@@ -137,6 +137,51 @@ describe('combohandler', function () {
             });
         });
 
+        it('should throw a 400 Bad Request error when a white-listed MIME type is not found', function (done) {
+            request(BASE_URL + '/js?foo.bar', function (err, res, body) {
+                assert.equal(err, null);
+                res.should.have.status(400);
+                body.should.equal('Bad request. Illegal MIME type present.');
+                done();
+            });
+        });
+
+        it('should throw a 400 Bad Request error when an unmapped MIME type is found with other valid types', function (done) {
+            request(BASE_URL + '/js?a.js&foo.bar', function (err, res, body) {
+                assert.equal(err, null);
+                res.should.have.status(400);
+                body.should.equal('Bad request. Only one MIME type allowed per request.');
+                done();
+            });
+        });
+
+        it('should throw a 400 Bad Request error when more than one valid MIME type is found', function (done) {
+            request(BASE_URL + '/js?a.js&b.css', function (err, res, body) {
+                assert.equal(err, null);
+                res.should.have.status(400);
+                body.should.equal('Bad request. Only one MIME type allowed per request.');
+                done();
+            });
+        });
+
+        it('should throw a 400 Bad Request error when a querystring is truncated', function (done) {
+            request(BASE_URL + '/js?a.js&b', function (err, res, body) {
+                assert.equal(err, null);
+                res.should.have.status(400);
+                body.should.equal('Bad request. Truncated query parameters.');
+                done();
+            });
+        });
+
+        it('should throw a 400 Bad Request error when a querystring is dramatically truncated', function (done) {
+            request(BASE_URL + '/js?a', function (err, res, body) {
+                assert.equal(err, null);
+                res.should.have.status(400);
+                body.should.equal('Bad request. Truncated query parameters.');
+                done();
+            });
+        });
+
         describe('path traversal', function () {
             var paths = [
                 '../../../../package.json',


### PR DESCRIPTION
- Deny requests with non-whitelisted or differing MIME types.
- Short-circuit requests that have been truncated or otherwise mangled.
- Tests!

Writing it as separate middleware did occur to me (extracting the MIME_TYPE config along with it), but for expediency's sake, it's inline.
