### PR TITLE
Test cleanup

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -17,21 +17,8 @@ describe('combohandler', function () {
         app = server({
             roots: {
                 '/css': __dirname + '/fixtures/root/css',
-                '/js' : __dirname + '/fixtures/root/js',
-                '/norewrite': __dirname + '/fixtures/rewrite'
+                '/js' : __dirname + '/fixtures/root/js'
             }
-        });
-        app.get('/rewrite', combo.combine({
-          rootPath: __dirname + '/fixtures/rewrite',
-          basePath: "/rewritten"
-        }), function (req, res) {
-          res.send(res.body);
-        });
-        app.get('/rewrite-noslash', combo.combine({
-          rootPath: __dirname + '/fixtures/rewrite',
-          basePath: "/rewritten/"
-        }), function (req, res) {
-          res.send(res.body);
         });
 
         httpServer = app.listen(PORT);
@@ -81,14 +68,14 @@ describe('combohandler', function () {
                 rootPath: __dirname + '/fixtures/root/js',
                 maxAge  : null
             }), function (req, res) {
-                res.send(res.body, 200);
+                res.send(res.body);
             });
 
             app.get('/max-age-0', combo.combine({
                 rootPath: __dirname + '/fixtures/root/js',
                 maxAge  : 0
             }), function (req, res) {
-                res.send(res.body, 200);
+                res.send(res.body);
             });
         });
 
@@ -227,6 +214,28 @@ describe('combohandler', function () {
 
     // -- URL Rewrites ---------------------------------------------------------
     describe("url rewrites", function () {
+        before(function () {
+            app.get('/norewrite', combo.combine({
+                rootPath: __dirname + '/fixtures/rewrite'
+            }), function (req, res) {
+                res.send(res.body);
+            });
+
+            app.get('/rewrite', combo.combine({
+                rootPath: __dirname + '/fixtures/rewrite',
+                basePath: "/rewritten"
+            }), function (req, res) {
+                res.send(res.body);
+            });
+
+            app.get('/rewrite-noslash', combo.combine({
+                rootPath: __dirname + '/fixtures/rewrite',
+                basePath: "/rewritten/"
+            }), function (req, res) {
+                res.send(res.body);
+            });
+        });
+
         it ("should allow the basePath to end in a slash", function (done) {
             request(BASE_URL + "/rewrite-noslash?urls.css", function (err, res, body) {
                 assert.equal(err, null);

--- a/test/server.js
+++ b/test/server.js
@@ -1,3 +1,4 @@
+/*global describe, before, after, it */
 var combo   = require('../'),
     server  = require('../lib/server'),
 
@@ -236,7 +237,7 @@ describe('combohandler', function () {
             });
         });
 
-        it ("should allow the basePath to end in a slash", function (done) {
+        it("should allow the basePath to end in a slash", function (done) {
             request(BASE_URL + "/rewrite-noslash?urls.css", function (err, res, body) {
                 assert.ifError(err);
                 body.should.equal([
@@ -248,12 +249,13 @@ describe('combohandler', function () {
                     "#data-url { background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==);}",
                     "#absolute-url { background: url(http://www.example.com/foo.gif?a=b&c=d#bebimbop);}",
                     "#protocol-relative-url { background: url(//www.example.com/foo.gif?a=b&c=d#bebimbop);}",
-                    "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }",
+                    "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }"
                 ].join("\n"));
                 done();
             });
         });
-        it ("should not rewrite without a basePath", function (done) {
+
+        it("should not rewrite without a basePath", function (done) {
             request(BASE_URL + "/norewrite?urls.css", function (err, res, body) {
                 assert.ifError(err);
                 body.should.equal([
@@ -270,7 +272,8 @@ describe('combohandler', function () {
                 done();
             });
         });
-        it ("should rewrite valid urls", function (done) {
+
+        it("should rewrite valid urls", function (done) {
             request(BASE_URL + "/rewrite?urls.css&deeper/more.css", function (err, res, body) {
                 assert.ifError(err);
                 body.should.equal([

--- a/test/server.js
+++ b/test/server.js
@@ -30,7 +30,7 @@ describe('combohandler', function () {
 
     it('should combine JavaScript', function (done) {
         request(BASE_URL + '/js?a.js&b.js', function (err, res, body) {
-            assert.equal(err, null);
+            assert.ifError(err);
             res.should.have.status(200);
             res.should.have.header('content-type', 'application/javascript;charset=utf-8');
             res.should.have.header('last-modified');
@@ -41,7 +41,7 @@ describe('combohandler', function () {
 
     it('should combine CSS', function (done) {
         request(BASE_URL + '/css?a.css&b.css', function (err, res, body) {
-            assert.equal(err, null);
+            assert.ifError(err);
             res.should.have.status(200);
             res.should.have.header('content-type', 'text/css;charset=utf-8');
             res.should.have.header('last-modified');
@@ -52,7 +52,7 @@ describe('combohandler', function () {
 
     it('should support symlinks pointing outside the root', function (done) {
         request(BASE_URL + '/js?a.js&b.js&outside.js', function (err, res, body) {
-            assert.equal(err, null);
+            assert.ifError(err);
             res.should.have.status(200);
             res.should.have.header('content-type', 'application/javascript;charset=utf-8');
             res.should.have.header('last-modified');
@@ -81,7 +81,7 @@ describe('combohandler', function () {
 
         it('should default to one year', function (done) {
             request(BASE_URL + '/js?a.js', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(200);
                 res.should.have.header('cache-control', 'public,max-age=31536000');
 
@@ -94,7 +94,7 @@ describe('combohandler', function () {
 
         it('should not set Cache-Control and Expires headers when maxAge is null', function (done) {
             request(BASE_URL + '/max-age-null?a.js', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(200);
                 res.headers.should.not.have.property('cache-control');
                 res.headers.should.not.have.property('expires');
@@ -104,7 +104,7 @@ describe('combohandler', function () {
 
         it('should support a maxAge of 0', function (done) {
             request(BASE_URL + '/max-age-0?a.js', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(200);
                 res.should.have.header('cache-control', 'public,max-age=0');
 
@@ -120,7 +120,7 @@ describe('combohandler', function () {
     describe('errors', function () {
         it('should return a 400 Bad Request error when no files are specified', function (done) {
             request(BASE_URL + '/js', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(400);
                 body.should.equal('Bad request. No files requested.');
                 done();
@@ -129,7 +129,7 @@ describe('combohandler', function () {
 
         it('should throw a 400 Bad Request error when a file is not found', function (done) {
             request(BASE_URL + '/js?bogus.js', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(400);
                 res.should.have.header('content-type', 'text/plain; charset=utf-8');
                 body.should.equal('Bad request. File not found: bogus.js');
@@ -139,7 +139,7 @@ describe('combohandler', function () {
 
         it('should throw a 400 Bad Request error when a white-listed MIME type is not found', function (done) {
             request(BASE_URL + '/js?foo.bar', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(400);
                 body.should.equal('Bad request. Illegal MIME type present.');
                 done();
@@ -148,7 +148,7 @@ describe('combohandler', function () {
 
         it('should throw a 400 Bad Request error when an unmapped MIME type is found with other valid types', function (done) {
             request(BASE_URL + '/js?a.js&foo.bar', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(400);
                 body.should.equal('Bad request. Only one MIME type allowed per request.');
                 done();
@@ -157,7 +157,7 @@ describe('combohandler', function () {
 
         it('should throw a 400 Bad Request error when more than one valid MIME type is found', function (done) {
             request(BASE_URL + '/js?a.js&b.css', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(400);
                 body.should.equal('Bad request. Only one MIME type allowed per request.');
                 done();
@@ -166,7 +166,7 @@ describe('combohandler', function () {
 
         it('should throw a 400 Bad Request error when a querystring is truncated', function (done) {
             request(BASE_URL + '/js?a.js&b', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(400);
                 body.should.equal('Bad request. Truncated query parameters.');
                 done();
@@ -175,7 +175,7 @@ describe('combohandler', function () {
 
         it('should throw a 400 Bad Request error when a querystring is dramatically truncated', function (done) {
             request(BASE_URL + '/js?a', function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 res.should.have.status(400);
                 body.should.equal('Bad request. Truncated query parameters.');
                 done();
@@ -201,7 +201,7 @@ describe('combohandler', function () {
             paths.forEach(function (path) {
                 it('should throw a 400 Bad Request error when path traversal is attempted: ' + path, function (done) {
                     request(BASE_URL + '/js?' + path, function (err, res, body) {
-                        assert.equal(err, null);
+                        assert.ifError(err);
                         res.should.have.status(400);
                         res.should.have.header('content-type', 'text/plain; charset=utf-8');
                         body.should.match(/^Bad request. File not found: /);
@@ -238,7 +238,7 @@ describe('combohandler', function () {
 
         it ("should allow the basePath to end in a slash", function (done) {
             request(BASE_URL + "/rewrite-noslash?urls.css", function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 body.should.equal([
                     "#no-quotes { background: url(/rewritten/no-quotes.png);}",
                     "#single-quotes { background: url(\'/rewritten/single-quotes.png\');}",
@@ -255,7 +255,7 @@ describe('combohandler', function () {
         });
         it ("should not rewrite without a basePath", function (done) {
             request(BASE_URL + "/norewrite?urls.css", function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 body.should.equal([
                     "#no-quotes { background: url(no-quotes.png);}",
                     "#single-quotes { background: url(\'single-quotes.png\');}",
@@ -272,7 +272,7 @@ describe('combohandler', function () {
         });
         it ("should rewrite valid urls", function (done) {
             request(BASE_URL + "/rewrite?urls.css&deeper/more.css", function (err, res, body) {
-                assert.equal(err, null);
+                assert.ifError(err);
                 body.should.equal([
                     "#no-quotes { background: url(/rewritten/no-quotes.png);}",
                     "#single-quotes { background: url(\'/rewritten/single-quotes.png\');}",

--- a/test/server.js
+++ b/test/server.js
@@ -3,7 +3,6 @@ var combo   = require('../'),
     server  = require('../lib/server'),
 
     assert  = require('assert'),
-    express = require('express'),
     request = require('request'),
 
     PORT     = 8942,


### PR DESCRIPTION
I've been poking around the tests lately, girding my loins for middleware-izing the stale PR https://github.com/rgrove/combohandler/pull/6 I made a year ago and another thing we want at Zillow, and I just couldn't stop my pesky habit of cleaning things that aren't noticeably dirty.

For the most part, the changes are for greater stylistic consistency. The routes tested by the `url rewrites` block should be described there, just like they are in the `config: maxAge` block. `assert.ifError(err)` is more concise than `assert.equal(err, null)`, since we're asserting that the callback did not error. And so on.

I also quieted the jshint errors, because I am a compulsive linter. :rabbit: 
