### PR TITLE
Add istanbul for code coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 pids/
 config.js
 npm-debug.log
+coverage/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 
     "devDependencies": {
         "istanbul": "~0.1.34",
-        "mocha"  : "1.6.0",
+        "mocha"  : "1.9.0",
         "request": "~2.9",
         "should" : "1.2.0"
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "directories": {"lib": "./lib"},
 
     "scripts": {
-        "test": "istanbul test ./node_modules/mocha/bin/_mocha"
+        "test": "istanbul test --print both ./node_modules/mocha/bin/_mocha"
     }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     },
 
     "devDependencies": {
+        "istanbul": "~0.1.34",
         "mocha"  : "1.6.0",
         "request": "~2.9",
         "should" : "1.2.0"
@@ -39,6 +40,6 @@
     "directories": {"lib": "./lib"},
 
     "scripts": {
-        "test": "./node_modules/.bin/mocha"
+        "test": "istanbul test ./node_modules/mocha/bin/_mocha"
     }
 }


### PR DESCRIPTION
`npm test --coverage` generates results, but basic `npm test` remains unsullied.

Already very impressive coverage! I just want help keeping it up to snuff when I write tests for the middleware-y stuff I'm cooking up.

``` text
----------------------+-----------+-----------+-----------+-----------+
File                  |   % Stmts |% Branches |   % Funcs |   % Lines |
----------------------+-----------+-----------+-----------+-----------+
   combohandler/      |       100 |       100 |       100 |       100 |
      index.js        |       100 |       100 |       100 |       100 |
   combohandler/lib/  |      93.4 |     88.89 |     90.48 |     94.29 |
      combohandler.js |     96.43 |     92.59 |       100 |     97.59 |
      server.js       |     81.82 |     66.67 |     66.67 |     81.82 |
----------------------+-----------+-----------+-----------+-----------+
All files             |     93.46 |     88.89 |     90.48 |     94.34 |
----------------------+-----------+-----------+-----------+-----------+
```
