### PR TITLE
Prepare for middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ app.use(combo.combine({rootPath: '/local/path/to/files'}));
 Or as route middleware for a specific route:
 
 ```js
-app.get('/foo', combo.combine({rootPath: '/local/path/to/foo'}), function (req, res) {
-    res.send(res.body);
-});
+app.get('/foo', combo.combine({rootPath: '/local/path/to/foo'}), combo.respond);
 ```
 
 In either case, the middleware will perform combo handling for files under the
@@ -105,12 +103,22 @@ app.use(function (err, req, res, next) {
 //
 // http://example.com/yui3?build/yui/yui-min.js&build/loader/loader-min.js
 //
-app.get('/yui3', combo.combine({rootPath: '/local/path/to/yui3'}), function (req, res) {
-    res.send(res.body);
-});
+app.get('/yui3', combo.combine({rootPath: '/local/path/to/yui3'}), combo.respond);
 
 app.listen(3000);
 ```
+
+#### `combo.respond`
+
+The `respond` method exported by `require('combohandler')` is a convenience method intended to be the last callback passed to an [express route](http://expressjs.com/api.html#app.VERB). Unless you have a *very* good reason to avoid it, you should probably use it. Here is the equivalent callback:
+
+```js
+function respond(req, res) {
+    res.send(res.body);
+}
+```
+
+This method may be extended in the future to do fancy things with optional combohandler middleware.
 
 ### Creating a server
 
@@ -182,12 +190,10 @@ app.use('/public', express.static(__dirname + '/public'));
 // also automatically rewrite relative paths in CSS files to point to the
 // non-combohandled static route defined above.
 //
-app.get('/combo', combohandler.combine({
+app.get('/combo', combo.combine({
     rootPath: __dirname + '/public',
     basePath: '/public'
-}), function (req, res) {
-    res.send(res.body);
-});
+}), combo.respond);
 ```
 
 Using as a YUI 3 combo handler

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ app.use(function (err, req, res, next) {
         res.type('text/plain');
         res.send(400, 'Bad request.');
     } else {
-        next();
+        next(err);
     }
 });
 

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -31,10 +31,6 @@ exports.combine = function (config) {
         maxAge = 31536000; // one year in seconds
     }
 
-    if ((/[^\/]$/).test(basePath)) {
-        basePath += "/";
-    }
-
     return function combineMiddleware(req, res, next) {
         var body    = [],
             query   = parseQuery(req.url),
@@ -186,10 +182,8 @@ function parseQuery(url) {
     return parsed;
 }
 
-function rewriteCSSURLs(base, path, data) {
+function rewriteCSSURLs(basePath, relativePath, data) {
     return data.replace(/[\s:]url\(\s*(['"]?)(\S+)\1\s*\)/g, function (substr, quote, match) {
-        var root,
-            dest;
         // There is a ton of complexity related to URL parsing related
         // to unicode, escapement, etc. Rather than try to capture that,
         // this just does a simple sniff to validate whether the URL
@@ -197,18 +191,11 @@ function rewriteCSSURLs(base, path, data) {
         if (!URI(match).is("relative")) {
             return substr;
         }
-        // the current directory
-        root = (base + path).split("/"),
-        // the place to which we're traversing
-        dest = match.split("/");
-        // pull off the file name
-        root.pop();
-        // while the destination contains "../", knock that off and
-        // knock off the last directory of root
-        while (dest.length > 1 && ".." === dest[0]) {
-            root.pop();
-            dest.shift();
-        }
-        return substr.replace(match, root.concat(dest).join("/"));
+
+        var fileBasePath = path.join(basePath, relativePath),
+            fileDirName  = path.dirname(fileBasePath),
+            absolutePath = path.resolve(fileDirName, match);
+
+        return substr.replace(match, absolutePath);
     });
 }

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -28,9 +28,9 @@ exports.combine = function (config) {
     if (typeof maxAge === 'undefined') {
         maxAge = 31536000; // one year in seconds
     }
-    
+
     if ((/[^\/]$/).test(basePath)) {
-      basePath += "/";
+        basePath += "/";
     }
 
     return function (req, res, next) {
@@ -196,7 +196,7 @@ function rewriteCSSURLs(base, path, data) {
         // this just does a simple sniff to validate whether the URL
         // needs to be rewritten.
         if (!URI(match).is("relative")) {
-          return substr;
+            return substr;
         }
         // the current directory
         root = (base + path).split("/"),

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -1,7 +1,9 @@
 var fs   = require('fs'),
     path = require('path'),
-    util = require('util'),
     URI  = require("URIjs"),
+
+    // exported to allow instanceof checks
+    BadRequest = exports.BadRequest = require('./error/bad-request'),
 
     // Default set of MIME types supported by the combo handler. Attempts to
     // combine one or more files with an extension not in this mapping (or not
@@ -130,18 +132,6 @@ exports.combine = function (config) {
 exports.respond = function (req, res) {
     res.send(res.body);
 };
-
-// BadRequest is used for all filesystem-related errors, including when a
-// requested file can't be found (a NotFound error wouldn't be appropriate in
-// that case since the route itself exists; it's the request that's at fault).
-function BadRequest(message) {
-    Error.call(this);
-    this.name = 'BadRequest';
-    this.message = message;
-    Error.captureStackTrace(this, arguments.callee);
-}
-util.inherits(BadRequest, Error);
-exports.BadRequest = BadRequest; // exported to allow instanceof checks
 
 // -- Private Methods ----------------------------------------------------------
 function decode(string) {

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -35,7 +35,7 @@ exports.combine = function (config) {
         basePath += "/";
     }
 
-    return function (req, res, next) {
+    return function combineMiddleware(req, res, next) {
         var body    = [],
             query   = parseQuery(req.url),
             pending = query.length,
@@ -129,7 +129,7 @@ exports.combine = function (config) {
 };
 
 // By convention, this is the last middleware passed to any combo route
-exports.respond = function (req, res) {
+exports.respond = function respondMiddleware(req, res) {
     res.send(res.body);
 };
 

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -122,6 +122,11 @@ exports.combine = function (config) {
     };
 };
 
+// By convention, this is the last middleware passed to any combo route
+exports.respond = function (req, res) {
+    res.send(res.body);
+};
+
 // BadRequest is used for all filesystem-related errors, including when a
 // requested file can't be found (a NotFound error wouldn't be appropriate in
 // that case since the route itself exists; it's the request that's at fault).

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -54,7 +54,11 @@ exports.combine = function (config) {
                 res.header('Expires', new Date(Date.now() + (maxAge * 1000)).toUTCString());
             }
 
-            res.header('Content-Type', (type || 'text/plain') + ';charset=utf-8');
+            // charset must be specified before contentType
+            // https://github.com/visionmedia/express/issues/1261
+            res.charset = 'utf-8';
+            res.contentType(type);
+
             res.body = body.join('\n');
 
             next();

--- a/lib/error/bad-request.js
+++ b/lib/error/bad-request.js
@@ -1,0 +1,12 @@
+// BadRequest is used for all filesystem-related errors, including when a
+// requested file can't be found (a NotFound error wouldn't be appropriate in
+// that case since the route itself exists; it's the request that's at fault).
+function BadRequest(message) {
+    Error.captureStackTrace(this, BadRequest);
+    this.name = 'BadRequest';
+    this.message = message;
+}
+
+require('util').inherits(BadRequest, Error);
+
+exports = module.exports = BadRequest;

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,7 @@ module.exports = function (config, baseApp) {
                 res.type('text/plain');
                 res.send(400, 'Bad request. ' + err.message);
             } else {
-                next();
+                next(err);
             }
         });
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -40,9 +40,7 @@ module.exports = function (config, baseApp) {
     }
 
     for (route in roots) {
-        app.get(route, combo.combine({rootPath: roots[route]}), function (req, res) {
-            res.send(res.body);
-        });
+        app.get(route, combo.combine({rootPath: roots[route]}), combo.respond);
     }
 
     return app;

--- a/test/server.js
+++ b/test/server.js
@@ -130,6 +130,13 @@ describe('combohandler', function () {
             }, combo.respond);
         });
 
+        it('should inherit from Error', function () {
+            var err = new combo.BadRequest('test');
+            err.should.be.an.instanceOf(Error);
+            err.name.should.equal('BadRequest');
+            err.message.should.equal('test');
+        });
+
         it('should return a 500 when error before middleware', function (done) {
             request(BASE_URL + '/error-next?a.js', function (err, res, body) {
                 assert.ifError(err);

--- a/test/server.js
+++ b/test/server.js
@@ -118,6 +118,26 @@ describe('combohandler', function () {
 
     // -- Errors ---------------------------------------------------------------
     describe('errors', function () {
+        before(function () {
+            var forceError = function (req, res, next) {
+                next(new Error('forced'));
+            };
+
+            app.get('/500?', combo.combine({
+                rootPath: __dirname + '/fixtures/root/js'
+            }), forceError, function (req, res) {
+                res.send(res.body);
+            });
+        });
+
+        it('should return a 500 when error is passed through (not a BadRequest)', function (done) {
+            request(BASE_URL + '/500?a.js', function (err, res, body) {
+                assert.ifError(err);
+                res.should.have.status(500);
+                done();
+            });
+        });
+
         it('should return a 400 Bad Request error when no files are specified', function (done) {
             request(BASE_URL + '/js', function (err, res, body) {
                 assert.ifError(err);

--- a/test/server.js
+++ b/test/server.js
@@ -67,16 +67,12 @@ describe('combohandler', function () {
             app.get('/max-age-null', combo.combine({
                 rootPath: __dirname + '/fixtures/root/js',
                 maxAge  : null
-            }), function (req, res) {
-                res.send(res.body);
-            });
+            }), combo.respond);
 
             app.get('/max-age-0', combo.combine({
                 rootPath: __dirname + '/fixtures/root/js',
                 maxAge  : 0
-            }), function (req, res) {
-                res.send(res.body);
-            });
+            }), combo.respond);
         });
 
         it('should default to one year', function (done) {
@@ -125,9 +121,7 @@ describe('combohandler', function () {
 
             app.get('/500?', combo.combine({
                 rootPath: __dirname + '/fixtures/root/js'
-            }), forceError, function (req, res) {
-                res.send(res.body);
-            });
+            }), forceError, combo.respond);
         });
 
         it('should return a 500 when error is passed through (not a BadRequest)', function (done) {
@@ -237,23 +231,17 @@ describe('combohandler', function () {
         before(function () {
             app.get('/norewrite', combo.combine({
                 rootPath: __dirname + '/fixtures/rewrite'
-            }), function (req, res) {
-                res.send(res.body);
-            });
+            }), combo.respond);
 
             app.get('/rewrite', combo.combine({
                 rootPath: __dirname + '/fixtures/rewrite',
                 basePath: "/rewritten"
-            }), function (req, res) {
-                res.send(res.body);
-            });
+            }), combo.respond);
 
             app.get('/rewrite-noslash', combo.combine({
                 rootPath: __dirname + '/fixtures/rewrite',
                 basePath: "/rewritten/"
-            }), function (req, res) {
-                res.send(res.body);
-            });
+            }), combo.respond);
         });
 
         it("should allow the basePath to end in a slash", function (done) {

--- a/test/server.js
+++ b/test/server.js
@@ -32,7 +32,7 @@ describe('combohandler', function () {
         request(BASE_URL + '/js?a.js&b.js', function (err, res, body) {
             assert.ifError(err);
             res.should.have.status(200);
-            res.should.have.header('content-type', 'application/javascript;charset=utf-8');
+            res.should.have.header('content-type', 'application/javascript; charset=utf-8');
             res.should.have.header('last-modified');
             body.should.equal('a();\n\nb();\n');
             done();
@@ -43,7 +43,7 @@ describe('combohandler', function () {
         request(BASE_URL + '/css?a.css&b.css', function (err, res, body) {
             assert.ifError(err);
             res.should.have.status(200);
-            res.should.have.header('content-type', 'text/css;charset=utf-8');
+            res.should.have.header('content-type', 'text/css; charset=utf-8');
             res.should.have.header('last-modified');
             body.should.equal('.a { color: green; }\n\n.b { color: green; }\n');
             done();
@@ -54,7 +54,7 @@ describe('combohandler', function () {
         request(BASE_URL + '/js?a.js&b.js&outside.js', function (err, res, body) {
             assert.ifError(err);
             res.should.have.status(200);
-            res.should.have.header('content-type', 'application/javascript;charset=utf-8');
+            res.should.have.header('content-type', 'application/javascript; charset=utf-8');
             res.should.have.header('last-modified');
             body.should.equal('a();\n\nb();\n\noutside();\n');
             done();


### PR DESCRIPTION
Mostly a collection of little tweaks to facilitate eventual middleware.

The goal with `combohandler#respond` is to provide a way to allow middleware to do stuff to the array of file contents, instead of having to deal with the joined array. Basically, moving the join (if res.body is an array) into the new `respond` middleware. Also, the duplication of the route-ending callback all over the examples and tests was bugging me.

I'm using the pull requests for ease of code review, but I'll probably just merge this one immediately. Subsequent PRs with a request for comment will happen with the more substantial middleware changes.
