### PR TITLE
CSS url() rewriting middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,24 @@ app.get('/combo', combo.combine({
 }), combo.respond);
 ```
 
+Alternatively, you can use the built-in `cssUrls` middleware as a separate
+route callback. `cssUrls` must always be placed after the default `combine`
+middleware when used in this fashion.
+
+```js
+// This route provides the same behaviour as the previous example, providing
+// better separation of concerns and the possibility of inserting custom
+// middleware between the built-in steps.
+app.get('/combo',
+    combo.combine({
+        rootPath: __dirname + '/public'
+    }),
+    combo.cssUrls({
+        basePath: '/public'
+    }),
+    combo.respond);
+```
+
 Using as a YUI 3 combo handler
 ------------------------------
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ app.get('/combo',
     combo.respond);
 ```
 
+Finally, the `cssUrls` middleware has the ability (disabled by default) to
+rewrite `@import` paths in the same manner as `url()` values. As `@import` is
+considered an anti-pattern in production code, this functionality is strictly
+opt-in and requires using `cssUrls` as a separate route callback. Import path
+rewriting is enabled by passing `true` as the `imports` property in the
+middleware options object.
+
+```js
+app.get('/combo',
+    combo.combine({ rootPath: __dirname + '/public' }),
+    combo.cssUrls({ basePath: '/public', imports: true }),
+    combo.respond);
+```
+
 Using as a YUI 3 combo handler
 ------------------------------
 

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -1,6 +1,5 @@
 var fs   = require('fs'),
     path = require('path'),
-    URI  = require("URIjs"),
 
     // exported to allow instanceof checks
     BadRequest = exports.BadRequest = require('./error/bad-request'),
@@ -21,6 +20,7 @@ exports.combine = function (config) {
     var maxAge    = config.maxAge,
         mimeTypes = config.mimeTypes || MIME_TYPES,
         basePath  = config.basePath || "",
+        rewriteCSSURLs,
 
         // Intentionally using the sync method because this only runs when the
         // middleware is initialized, and we want it to throw if there's an
@@ -29,6 +29,10 @@ exports.combine = function (config) {
 
     if (typeof maxAge === 'undefined') {
         maxAge = 31536000; // one year in seconds
+    }
+
+    if (basePath) {
+        rewriteCSSURLs = require('./middleware/cssUrls').rewrite;
     }
 
     return function combineMiddleware(req, res, next) {
@@ -182,20 +186,3 @@ function parseQuery(url) {
     return parsed;
 }
 
-function rewriteCSSURLs(basePath, relativePath, data) {
-    return data.replace(/[\s:]url\(\s*(['"]?)(\S+)\1\s*\)/g, function (substr, quote, match) {
-        // There is a ton of complexity related to URL parsing related
-        // to unicode, escapement, etc. Rather than try to capture that,
-        // this just does a simple sniff to validate whether the URL
-        // needs to be rewritten.
-        if (!URI(match).is("relative")) {
-            return substr;
-        }
-
-        var fileBasePath = path.join(basePath, relativePath),
-            fileDirName  = path.dirname(fileBasePath),
-            absolutePath = path.resolve(fileDirName, match);
-
-        return substr.replace(match, absolutePath);
-    });
-}

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -61,6 +61,13 @@ exports.combine = function (config) {
             res.charset = 'utf-8';
             res.contentType(type);
 
+            // provide metadata to subsequent middleware via res.locals
+            res.locals({
+                relativePaths: query,
+                bodyContents: body,
+                basePath: basePath
+            });
+
             res.body = body.join('\n');
 
             next();
@@ -186,3 +193,13 @@ function parseQuery(url) {
     return parsed;
 }
 
+// Auto-load bundled middleware with getters, Connect-style
+exports.middleware = {};
+
+fs.readdirSync(__dirname + '/middleware').forEach(function (filename) {
+    if (!/\.js$/.test(filename)) { return; }
+    var name = path.basename(filename, '.js');
+    function load() { return require('./middleware/' + name); }
+    exports.middleware.__defineGetter__(name, load);
+    exports.__defineGetter__(name, load);
+});

--- a/lib/middleware/cssUrls.js
+++ b/lib/middleware/cssUrls.js
@@ -7,20 +7,19 @@ var URI  = require("URIjs");
 
 var replacer = function replacer(basePath, relativePath) {
     return function (substr, quote, match) {
-        var parsedURI = URI(match);
-
         // There is a ton of complexity related to URL parsing related
         // to unicode, escapement, etc. Rather than try to capture that,
         // this just does a simple sniff to validate whether the URL
         // needs to be rewritten.
-        if (!parsedURI.is("relative")) {
+        if (!URI(match).is("relative")) {
             return substr;
         }
 
         var fileBasePath = path.join(basePath, relativePath),
-            absolutePath = parsedURI.absoluteTo(fileBasePath);
+            fileDirName  = path.dirname(fileBasePath),
+            absolutePath = path.resolve(fileDirName, match);
 
-        return substr.replace(match, URI.decode(absolutePath));
+        return substr.replace(match, absolutePath);
     };
 };
 

--- a/lib/middleware/cssUrls.js
+++ b/lib/middleware/cssUrls.js
@@ -50,7 +50,7 @@ exports = module.exports = function (options) {
 };
 
 exports.rewrite = function rewriteCSSURLs(basePath, relativePath, data) {
-    return data.replace(/[\s:]url\(\s*(['"]?)(\S+)\1\s*\)/g, replacer(basePath, relativePath));
+    return data.replace(/:\s*url\(\s*(['"]?)(\S+)\1\s*\)/g, replacer(basePath, relativePath));
 };
 
 function isCSS(res) {

--- a/lib/middleware/cssUrls.js
+++ b/lib/middleware/cssUrls.js
@@ -7,19 +7,20 @@ var URI  = require("URIjs");
 
 var replacer = function replacer(basePath, relativePath) {
     return function (substr, quote, match) {
+        var parsedURI = URI(match);
+
         // There is a ton of complexity related to URL parsing related
         // to unicode, escapement, etc. Rather than try to capture that,
         // this just does a simple sniff to validate whether the URL
         // needs to be rewritten.
-        if (!URI(match).is("relative")) {
+        if (!parsedURI.is("relative")) {
             return substr;
         }
 
         var fileBasePath = path.join(basePath, relativePath),
-            fileDirName  = path.dirname(fileBasePath),
-            absolutePath = path.resolve(fileDirName, match);
+            absolutePath = parsedURI.absoluteTo(fileBasePath);
 
-        return substr.replace(match, absolutePath);
+        return substr.replace(match, URI.decode(absolutePath));
     };
 };
 

--- a/lib/middleware/cssUrls.js
+++ b/lib/middleware/cssUrls.js
@@ -5,6 +5,9 @@ absolute paths based on config (basePath).
 var path = require('path');
 var URI  = require("URIjs");
 
+var RX_URL = /:\s*url\(\s*(['"]?)(\S+)\1\s*\)/g;
+var RX_IMPORT = /\@import\s*(?:url\(\s*)?(['"]?)(\S+)\1(?:\s*\))?[^;'"]*;/g;
+
 var replacer = function replacer(basePath, relativePath) {
     return function (substr, quote, match) {
         // There is a ton of complexity related to URL parsing related
@@ -23,8 +26,26 @@ var replacer = function replacer(basePath, relativePath) {
     };
 };
 
+/**
+Route middleware that rewrites relative paths found in CSS source
+url() values absolutized to the configured basePath.
+
+Optionally, @import directives can be similarly processed.
+
+@method cssUrls
+@param {Object} options
+    @param {String} basePath
+    @param {Boolean} [imports=false]
+@return {Function}
+**/
 exports = module.exports = function (options) {
     options = options || {};
+
+    // @import directives are considered an anti-pattern
+    // in production code, so this feature is explicitly
+    // opt-in only.
+    var importsEnabled = (true === options.imports);
+
     return function cssUrlsMiddleware(req, res, next) {
         var bodyContents,
             relativePaths,
@@ -37,7 +58,7 @@ exports = module.exports = function (options) {
             if (relativePaths.length && bodyContents.length) {
                 // synchronous replacement
                 relativePaths.forEach(function (relativePath, i) {
-                    bodyContents[i] = exports.rewrite(basePath, relativePath, bodyContents[i]);
+                    bodyContents[i] = exports.rewrite(basePath, relativePath, bodyContents[i], importsEnabled);
                 });
 
                 // overwrites response body with replaced content
@@ -49,8 +70,14 @@ exports = module.exports = function (options) {
     };
 };
 
-exports.rewrite = function rewriteCSSURLs(basePath, relativePath, data) {
-    return data.replace(/:\s*url\(\s*(['"]?)(\S+)\1\s*\)/g, replacer(basePath, relativePath));
+exports.rewrite = function rewriteCSSURLs(basePath, relativePath, data, importsEnabled) {
+    var replaceCallback = replacer(basePath, relativePath);
+
+    if (importsEnabled) {
+        data = data.replace(RX_IMPORT, replaceCallback);
+    }
+
+    return data.replace(RX_URL, replaceCallback);
 };
 
 function isCSS(res) {

--- a/lib/middleware/cssUrls.js
+++ b/lib/middleware/cssUrls.js
@@ -23,6 +23,36 @@ var replacer = function replacer(basePath, relativePath) {
     };
 };
 
+exports = module.exports = function (options) {
+    options = options || {};
+    return function cssUrlsMiddleware(req, res, next) {
+        var bodyContents,
+            relativePaths,
+            basePath = res.locals.basePath || options.basePath;
+
+        if (basePath && isCSS(res)) {
+            relativePaths = res.locals.relativePaths || [];
+            bodyContents  = res.locals.bodyContents  || [];
+
+            if (relativePaths.length && bodyContents.length) {
+                // synchronous replacement
+                relativePaths.forEach(function (relativePath, i) {
+                    bodyContents[i] = exports.rewrite(basePath, relativePath, bodyContents[i]);
+                });
+
+                // overwrites response body with replaced content
+                res.body = bodyContents.join('\n');
+            }
+        }
+
+        next();
+    };
+};
+
 exports.rewrite = function rewriteCSSURLs(basePath, relativePath, data) {
     return data.replace(/[\s:]url\(\s*(['"]?)(\S+)\1\s*\)/g, replacer(basePath, relativePath));
 };
+
+function isCSS(res) {
+    return res.get('Content-Type').indexOf('text/css') > -1;
+}

--- a/lib/middleware/cssUrls.js
+++ b/lib/middleware/cssUrls.js
@@ -1,0 +1,28 @@
+/**
+Middleware that rewrites relative url() and import paths into
+absolute paths based on config (basePath).
+**/
+var path = require('path');
+var URI  = require("URIjs");
+
+var replacer = function replacer(basePath, relativePath) {
+    return function (substr, quote, match) {
+        // There is a ton of complexity related to URL parsing related
+        // to unicode, escapement, etc. Rather than try to capture that,
+        // this just does a simple sniff to validate whether the URL
+        // needs to be rewritten.
+        if (!URI(match).is("relative")) {
+            return substr;
+        }
+
+        var fileBasePath = path.join(basePath, relativePath),
+            fileDirName  = path.dirname(fileBasePath),
+            absolutePath = path.resolve(fileDirName, match);
+
+        return substr.replace(match, absolutePath);
+    };
+};
+
+exports.rewrite = function rewriteCSSURLs(basePath, relativePath, data) {
+    return data.replace(/[\s:]url\(\s*(['"]?)(\S+)\1\s*\)/g, replacer(basePath, relativePath));
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 
     "dependencies": {
         "express": "3.1.1",
-        "URIjs"  : "1.10.0"
+        "URIjs"  : "1.10.1"
     },
 
     "devDependencies": {

--- a/test/fixtures/rewrite/imports.css
+++ b/test/fixtures/rewrite/imports.css
@@ -1,0 +1,12 @@
+@import 'basic-sq.css';
+@import "basic-dq.css";
+@import url(url-uq.css);
+@import url('url-sq.css');
+@import url("url-dq.css");
+@import "media-simple.css" print;
+@import url("media-simple-url.css") print;
+@import 'media-simple-comma.css' print, screen;
+@import "media-complex.css" screen and (min-width: 400px) and (max-width: 700px);
+@import url("media-complex-url.css") screen and (min-width: 400px) and (max-width: 700px);
+@import "../rewrite/deeper/more.css";
+@import "../root/css/a.css" (device-width: 320px);

--- a/test/fixtures/rewrite/urls.css
+++ b/test/fixtures/rewrite/urls.css
@@ -9,3 +9,6 @@
 #escaped-stuff { background:url("\)\";\'\(.png"); }
 .unicode-raw { background: url(déchaîné.png); }
 .unicode-escaped { background: url(d\0000E9cha\EEn\E9.png); }
+.nl-craziness { background:
+    url(crazy.png
+    ); }

--- a/test/fixtures/rewrite/urls.css
+++ b/test/fixtures/rewrite/urls.css
@@ -7,3 +7,5 @@
 #absolute-url { background: url(http://www.example.com/foo.gif?a=b&c=d#bebimbop);}
 #protocol-relative-url { background: url(//www.example.com/foo.gif?a=b&c=d#bebimbop);}
 #escaped-stuff { background:url("\)\";\'\(.png"); }
+.unicode-raw { background: url(déchaîné.png); }
+.unicode-escaped { background: url(d\0000E9cha\EEn\E9.png); }

--- a/test/server.js
+++ b/test/server.js
@@ -277,7 +277,10 @@ describe('combohandler', function () {
                     "#data-url { background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==);}",
                     "#absolute-url { background: url(http://www.example.com/foo.gif?a=b&c=d#bebimbop);}",
                     "#protocol-relative-url { background: url(//www.example.com/foo.gif?a=b&c=d#bebimbop);}",
-                    "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }"
+                    "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }",
+                    ".unicode-raw { background: url(/rewritten/déchaîné.png); }",
+                    ".unicode-escaped { background: url(/rewritten/d\\0000E9cha\\EEn\\E9.png); }",
+                    ""
                 ].join("\n"));
                 done();
             });
@@ -295,7 +298,10 @@ describe('combohandler', function () {
                     "#data-url { background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==);}",
                     "#absolute-url { background: url(http://www.example.com/foo.gif?a=b&c=d#bebimbop);}",
                     "#protocol-relative-url { background: url(//www.example.com/foo.gif?a=b&c=d#bebimbop);}",
-                    "#escaped-stuff { background:url(\"\\)\\\";\\'\\(.png\"); }"
+                    "#escaped-stuff { background:url(\"\\)\\\";\\'\\(.png\"); }",
+                    ".unicode-raw { background: url(déchaîné.png); }",
+                    ".unicode-escaped { background: url(d\\0000E9cha\\EEn\\E9.png); }",
+                    ""
                 ].join("\n"));
                 done();
             });
@@ -314,6 +320,11 @@ describe('combohandler', function () {
                     "#absolute-url { background: url(http://www.example.com/foo.gif?a=b&c=d#bebimbop);}",
                     "#protocol-relative-url { background: url(//www.example.com/foo.gif?a=b&c=d#bebimbop);}",
                     "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }",
+                    ".unicode-raw { background: url(/rewritten/déchaîné.png); }",
+                    // NOTE: we do not currently support the space terminator for CSS escapes.
+                    // ".unicode-escaped { background: url(/rewritten/d\\E9 cha\\EEn\\E9.png); }",
+                    ".unicode-escaped { background: url(/rewritten/d\\0000E9cha\\EEn\\E9.png); }",
+                    "",
                     "#depth { background: url(/rewritten/deeper/deeper.png);}",
                     "#up-one { background: url(/rewritten/shallower.png);}",
                     "#down-one { background: url(/rewritten/deeper/more/down-one.png);}"
@@ -359,6 +370,9 @@ describe('combohandler', function () {
                         "#absolute-url { background: url(http://www.example.com/foo.gif?a=b&c=d#bebimbop);}",
                         "#protocol-relative-url { background: url(//www.example.com/foo.gif?a=b&c=d#bebimbop);}",
                         "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }",
+                        ".unicode-raw { background: url(/rewritten/déchaîné.png); }",
+                        ".unicode-escaped { background: url(/rewritten/d\\0000E9cha\\EEn\\E9.png); }",
+                        "",
                         "#depth { background: url(/rewritten/deeper/deeper.png);}",
                         "#up-one { background: url(/rewritten/shallower.png);}",
                         "#down-one { background: url(/rewritten/deeper/more/down-one.png);}"

--- a/test/server.js
+++ b/test/server.js
@@ -280,6 +280,9 @@ describe('combohandler', function () {
                     "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }",
                     ".unicode-raw { background: url(/rewritten/déchaîné.png); }",
                     ".unicode-escaped { background: url(/rewritten/d\\0000E9cha\\EEn\\E9.png); }",
+                    ".nl-craziness { background:",
+                    "    url(/rewritten/crazy.png",
+                    "    ); }",
                     ""
                 ].join("\n"));
                 done();
@@ -301,6 +304,9 @@ describe('combohandler', function () {
                     "#escaped-stuff { background:url(\"\\)\\\";\\'\\(.png\"); }",
                     ".unicode-raw { background: url(déchaîné.png); }",
                     ".unicode-escaped { background: url(d\\0000E9cha\\EEn\\E9.png); }",
+                    ".nl-craziness { background:",
+                    "    url(crazy.png",
+                    "    ); }",
                     ""
                 ].join("\n"));
                 done();
@@ -324,6 +330,9 @@ describe('combohandler', function () {
                     // NOTE: we do not currently support the space terminator for CSS escapes.
                     // ".unicode-escaped { background: url(/rewritten/d\\E9 cha\\EEn\\E9.png); }",
                     ".unicode-escaped { background: url(/rewritten/d\\0000E9cha\\EEn\\E9.png); }",
+                    ".nl-craziness { background:",
+                    "    url(/rewritten/crazy.png",
+                    "    ); }",
                     "",
                     "#depth { background: url(/rewritten/deeper/deeper.png);}",
                     "#up-one { background: url(/rewritten/shallower.png);}",
@@ -372,6 +381,9 @@ describe('combohandler', function () {
                         "#escaped-stuff { background:url(\"/rewritten/\\)\\\";\\'\\(.png\"); }",
                         ".unicode-raw { background: url(/rewritten/déchaîné.png); }",
                         ".unicode-escaped { background: url(/rewritten/d\\0000E9cha\\EEn\\E9.png); }",
+                        ".nl-craziness { background:",
+                        "    url(/rewritten/crazy.png",
+                        "    ); }",
                         "",
                         "#depth { background: url(/rewritten/deeper/deeper.png);}",
                         "#up-one { background: url(/rewritten/shallower.png);}",


### PR DESCRIPTION
This builds on @RCanine's work with the `rewriteCSSURLs` helper function by extracting it into an Express/Connect-style middleware function, while maintaining backward-compatibility when the `basePath` config is passed to the `combine` middleware.

I plan on letting this PR stew for at least a day, I have some comments to make about certain bits of code.
