### PR TITLE
v0.3.4 - Enhance args export for external re-use

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,14 @@
 Combo Handler History
 =====================
 
+0.3.4 (2013-04-29)
+------------------
+
+* Encapsulated option-based instance CLI behaviour with args.invoke().
+
+* Exposed CLI option config on the exported object to allow ad-hoc
+  customization for those that `require('combohandler/lib/args')`.
+
 0.3.3 (2013-04-26)
 ------------------
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,21 +16,7 @@ if (options.cluster) {
     // Cluster support
     instance = require('../lib/cluster')(options);
 
-    if (options.restart) {
-        instance.restart();
-    }
-    else if (options.shutdown) {
-        instance.shutdown();
-    }
-    else if (options.status) {
-        instance.status();
-    }
-    else if (options.stop) {
-        instance.stop();
-    }
-    else {
-        instance.listen();
-    }
+    args.invoke(instance);
 } else {
     // Legacy support
     instance = require('../lib/server')(options);

--- a/lib/args.js
+++ b/lib/args.js
@@ -111,6 +111,30 @@ exports = module.exports = {
         });
 
         return resolveRoots(config);
+    },
+    /**
+    Encapsulates behaviour of an instance when created via CLI.
+
+    @method invoke
+    @param {ComboCluster} instance
+    **/
+    invoke: function (instance) {
+        var options = instance.options;
+        if (options.restart) {
+            instance.restart();
+        }
+        else if (options.shutdown) {
+            instance.shutdown();
+        }
+        else if (options.status) {
+            instance.status();
+        }
+        else if (options.stop) {
+            instance.stop();
+        }
+        else {
+            instance.listen();
+        }
     }
 };
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -41,6 +41,8 @@ var shortHands = {
 };
 
 exports = module.exports = {
+    knownOpts: knownOpts,
+    shortHands: shortHands,
     /*jshint es5: true */
     get usage() {
         var msg = [];

--- a/test/test-args.js
+++ b/test/test-args.js
@@ -3,7 +3,6 @@ var path = require('path');
 var args = require('../lib/args');
 
 describe("args", function () {
-
     describe("parse()", function () {
         it("should consume ad-hoc string 'restart' param as boolean config.restart", function () {
             var config = args.parse(['restart'], 0);
@@ -143,5 +142,25 @@ describe("args", function () {
 
             gotVersion.should.equal(pkgVersion);
         });
+    });
+
+    describe("invoke()", function () {
+        function assertMethodCalled(methodName) {
+            return function (done) {
+                var instance = {
+                    options: {}
+                };
+                instance[methodName] = done;
+                instance.options[methodName] = true;
+
+                args.invoke(instance);
+            };
+        }
+
+        it("should call restart() when options.restart present",    assertMethodCalled("restart"));
+        it("should call shutdown() when options.shutdown present",  assertMethodCalled("shutdown"));
+        it("should call status() when options.status present",      assertMethodCalled("status"));
+        it("should call stop() when options.stop present",          assertMethodCalled("stop"));
+        it("should call listen() when no other options present",    assertMethodCalled("listen"));
     });
 });

--- a/test/test-args.js
+++ b/test/test-args.js
@@ -39,6 +39,40 @@ describe("args", function () {
             config.should.not.have.property('status');
             config.stop.should.equal(true);
         });
+
+        describe("with augmented knownOpts", function () {
+            args.knownOpts["ad-hoc-path"] = path;
+            args.knownOpts["ad-hoc-many"] = [String, Array];
+
+            it("should parse --ad-hoc-path as a resolved path", function () {
+                var config = args.parse(['--ad-hoc-path', './test/fixtures'], 0);
+
+                config.should.have.property('ad-hoc-path');
+                config['ad-hoc-path'].should.equal(path.resolve(__dirname, 'fixtures'));
+            });
+
+            it("should parse --ad-hoc-many as an array of strings", function () {
+                var config = args.parse([
+                    '--ad-hoc-many', 'foo',
+                    '--ad-hoc-many', 'bar',
+                    '--ad-hoc-many', 'baz'
+                ], 0);
+
+                config.should.have.property('ad-hoc-many');
+                config['ad-hoc-many'].should.eql(['foo', 'bar', 'baz']);
+            });
+        });
+
+        describe("with augmented shortHands", function () {
+            args.shortHands.foo = ["--ad-hoc-path", "./test/fixtures"];
+
+            it("should parse --foo as '--ad-hoc-path ./test/fixtures'", function () {
+                var config = args.parse(['--foo'], 0);
+
+                config.should.have.property('ad-hoc-path');
+                config['ad-hoc-path'].should.equal(path.resolve(__dirname, 'fixtures'));
+            });
+        });
     });
 
     describe("clean()", function () {


### PR DESCRIPTION
I found myself wanting to accept ad-hoc arguments in the wrapper utility I wrote for internal use of combohandler at Zillow. `nopt` allows this, of course, but it requires wonky options syntax, and I'd rather keep stuff as robust as possible.

Also, I needed a way to replicate the conditional behaviour of the cluster instance when certain options were present. Copypasta works, but abstraction is better!
