### PR TITLE
errorMaxAge config sets caching headers on BadRequest error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ app.configure(function () {
 });
 
 // Return a 400 response if the combo handler generates a BadRequest error.
-app.use(combo.errorHandler);
+app.use(combo.errorHandler());
 
 // Given a root path that points to a YUI 3 root folder, this route will
 // handle URLs like:
@@ -126,6 +126,26 @@ function respond(req, res) {
 
 This method may be extended in the future to do fancy things with optional
 combohandler middleware.
+
+#### `combo.errorHandler`
+
+The `errorHandler` export encapsulates the convention of sending `BadRequest`
+errors with an optional `errorMaxAge` config.
+By default, `BadRequest` errors are served with a 5 minute `max-age` header.
+
+To explicitly disable caching (via
+`Pragma: no-cache` and
+`Cache-Control: private,no-store`
+headers), pass `null` in the options object:
+
+```js
+app.use(combo.errorHandler({
+    errorMaxAge: null
+}));
+```
+
+Any other value (including zero) for `errorMaxAge` is interpreted as the
+desired duration in seconds.
 
 ### Creating a server
 

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -149,14 +149,37 @@ exports.combine = function (config) {
     return callbacks;
 };
 
-exports.errorHandler = function comboErrorHandler(err, req, res, next) {
-    if (err instanceof BadRequest) {
-        res.charset = 'utf-8';
-        res.type('text/plain');
-        res.send(400, 'Bad request. ' + err.message);
-    } else {
-        next(err);
+exports.errorHandler = function (options) {
+    if (!options) {
+        options = {};
     }
+
+    // pass null to disable caching
+    var errorAge = options.errorMaxAge;
+
+    if (typeof errorAge === 'undefined') {
+        errorAge = 300; // five minutes in seconds
+    }
+
+    return function comboErrorHandler(err, req, res, next) {
+        if (err instanceof BadRequest) {
+            res.charset = 'utf-8';
+            res.type('text/plain');
+
+            if (errorAge !== null) {
+                res.header('Cache-Control', 'public,max-age=' + errorAge);
+                res.header('Expires', new Date(Date.now() + (errorAge * 1000)).toUTCString());
+            } else {
+                res.header('Cache-Control', 'private,no-store');
+                res.header('Expires', new Date(0).toUTCString());
+                res.header('Pragma', 'no-cache');
+            }
+
+            res.send(400, 'Bad request. ' + err.message);
+        } else {
+            next(err);
+        }
+    };
 };
 
 // By convention, this is the last middleware passed to any combo route

--- a/lib/server.js
+++ b/lib/server.js
@@ -29,7 +29,7 @@ module.exports = function (config, baseApp) {
 
         app.use(app.router);
 
-        app.use(combo.errorHandler);
+        app.use(combo.errorHandler());
     }
 
     for (route in roots) {

--- a/test/server.js
+++ b/test/server.js
@@ -122,6 +122,64 @@ describe('combohandler', function () {
         });
     });
 
+    describe('config: errorMaxAge', function () {
+        before(function () {
+            function throwBadRequest(req, res, next) {
+                next(new combo.BadRequest('errorMaxAge'));
+            }
+
+            app.use('/error-max-age-null', throwBadRequest);
+            app.use('/error-max-age-null', combo.errorHandler({
+                errorMaxAge: null
+            }));
+
+            app.use('/error-max-age-0', throwBadRequest);
+            app.use('/error-max-age-0', combo.errorHandler({
+                errorMaxAge: 0
+            }));
+        });
+
+        it('should default to five minutes', function (done) {
+            request(BASE_URL + '/js?err.js', function (err, res, body) {
+                res.should.have.status(400);
+                res.should.have.header('cache-control', 'public,max-age=300');
+
+                var expires = new Date(res.headers['expires']);
+                ((expires - Date.now()) / 1000).should.be.within(290, 300);
+
+                done();
+            });
+        });
+
+        it('should set private Cache-Control and no-cache headers when errorMaxAge is null', function (done) {
+            request(BASE_URL + '/error-max-age-null?a.js', function (err, res, body) {
+                assert.ifError(err);
+                res.should.have.status(400);
+                res.should.have.header('cache-control', 'private,no-store');
+                res.should.have.header('pragma', 'no-cache');
+
+                res.headers.should.have.property('expires');
+                var expires = new Date(res.headers['expires']).getTime();
+                expires.should.equal(new Date(0).getTime());
+
+                done();
+            });
+        });
+
+        it('should support an errorMaxAge of 0', function (done) {
+            request(BASE_URL + '/error-max-age-0?a.js', function (err, res, body) {
+                assert.ifError(err);
+                res.should.have.status(400);
+                res.should.have.header('cache-control', 'public,max-age=0');
+
+                var expires = new Date(res.headers['expires']);
+                ((expires - Date.now()) / 1000).should.be.within(-5, 5);
+
+                done();
+            });
+        });
+    });
+
     describe('config: basePath', function () {
         describe('when absent', function () {
             it("should NOT append cssUrls middleware to callbacks", function () {

--- a/test/server.js
+++ b/test/server.js
@@ -148,7 +148,8 @@ describe('combohandler', function () {
                 res.should.have.status(400);
                 res.should.have.header('cache-control', 'public,max-age=300');
 
-                var expires = new Date(res.headers['expires']);
+                res.headers.should.have.property('expires');
+                var expires = new Date(res.headers.expires);
                 ((expires - Date.now()) / 1000).should.be.within(290, 300);
 
                 done();
@@ -163,7 +164,7 @@ describe('combohandler', function () {
                 res.should.have.header('pragma', 'no-cache');
 
                 res.headers.should.have.property('expires');
-                var expires = new Date(res.headers['expires']).getTime();
+                var expires = new Date(res.headers.expires).getTime();
                 expires.should.equal(new Date(0).getTime());
 
                 done();
@@ -176,7 +177,8 @@ describe('combohandler', function () {
                 res.should.have.status(400);
                 res.should.have.header('cache-control', 'public,max-age=0');
 
-                var expires = new Date(res.headers['expires']);
+                res.headers.should.have.property('expires');
+                var expires = new Date(res.headers.expires);
                 ((expires - Date.now()) / 1000).should.be.within(-5, 5);
 
                 done();


### PR DESCRIPTION
Very similar to `maxAge`, except the `null` config sets explict `Pragma: no-cache` headers instead of omitting them entirely.
