### PR TITLE
Allow multiple route parameters in dynamicPath middleware

### DIFF
--- a/lib/middleware/dynamicPath.js
+++ b/lib/middleware/dynamicPath.js
@@ -50,22 +50,25 @@ exports = module.exports = function (options) {
 
 function getDynamicRoot(params, opts, cb) {
     var rootPath = opts.rootPath;
-    var dynamicParam = opts.dynamicParam;
-    var rootSuffix = opts.rootSuffix;
+    var dynamicParams = opts.dynamicParams;
+    var rootSuffixes = opts.rootSuffixes;
     var statCache = opts.statCache;
-
-    var dynamicValue = dynamicParam && params[dynamicParam];
     var dynamicRoot;
 
-    // a dynamic parameter has been configured
-    if (dynamicValue) {
-        // rootSuffix contributes to cache key
-        if (rootSuffix) {
-            dynamicValue = path.join(dynamicValue, rootSuffix);
+    dynamicParams.forEach(function (dynamicParam) {
+        var dynamicValue = dynamicParam && params[dynamicParam];
+        if (dynamicValue) {
+            // rootSuffixes contribute to cache key
+            if (rootSuffixes[dynamicParam]) {
+                dynamicValue = path.join(dynamicValue, rootSuffixes[dynamicParam]);
+            }
+
+            dynamicRoot = path.normalize(path.join(dynamicRoot || rootPath, dynamicValue));
         }
+    });
 
-        dynamicRoot = path.normalize(path.join(rootPath, dynamicValue));
-
+    // one or more dynamic parameters have been configured
+    if (dynamicRoot) {
         if (statCache[dynamicRoot]) {
             // a path has already been resolved
             cb(null, dynamicRoot);
@@ -89,10 +92,10 @@ function getDynamicRoot(params, opts, cb) {
     }
 }
 
-function getDynamicKey(rootPath) {
+function getDynamicKeys(rootPath) {
     // route parameter matches ":foo" of "/:foo/bar/"
-    var paramRegex = /:\w+/;
-    return paramRegex.test(rootPath) && rootPath.match(paramRegex)[0];
+    // as well as ":baz" and ":qux" of "/:baz/:qux/"
+    return rootPath.match(/:\w+/g);
 }
 
 /**
@@ -103,31 +106,37 @@ Create a config object for use in dynamicPathMiddleware.
 @return {Object} config
     @property {String} config.rootPath
     @property {String} config.dynamicParam
-    @property {String} config.rootSuffix
+    @property {String} config.rootSuffixes
     @property {String} config.statCache
 @private
 **/
 function parseConfig(rootPath) {
     rootPath = path.normalize(rootPath);
 
-    var dynamicKey = getDynamicKey(rootPath),
-        dynamicParam,
-        rootSuffix;
+    var dynamicKeys = getDynamicKeys(rootPath);
+    var dynamicParams = [];
+    var rootSuffixes = {};
 
     // str.match() in route config returns null if no matches or [":foo"]
-    if (dynamicKey) {
-        // key for the req.params must be stripped of the colon
-        dynamicParam = dynamicKey.substr(1);
+    if (dynamicKeys) {
+        dynamicKeys.reverse().forEach(function (dynamicKey) {
+            // key for the req.params must be stripped of the colon
+            var keyName = dynamicKey.substr(1);
 
-        // if the parameter is not the last token in the rootPath
-        // (e.g., '/foo/:version/bar/')
-        if (path.basename(rootPath).indexOf(dynamicKey) === -1) {
-            // rootSuffix must be stored for use in getDynamicRoot
-            rootSuffix = rootPath.substr(rootPath.indexOf(dynamicKey) + dynamicKey.length);
-        }
+            // since we're iterating in reverse, we need to maintain
+            // expected path order by always adding to the beginning
+            dynamicParams.unshift(keyName);
 
-        // remove key + suffix from rootPath used in initial realpathSync
-        rootPath = rootPath.substring(0, rootPath.indexOf(dynamicKey));
+            // if the parameter is not the last token in the rootPath
+            // (e.g., '/foo/:version/bar/')
+            if (path.basename(rootPath).indexOf(dynamicKey) === -1) {
+                // rootSuffixes must be stored for use in getDynamicRoot
+                rootSuffixes[keyName] = rootPath.substr(rootPath.indexOf(dynamicKey) + dynamicKey.length);
+            }
+
+            // remove key + suffix from rootPath used in initial realpathSync
+            rootPath = rootPath.substring(0, rootPath.indexOf(dynamicKey));
+        });
     }
 
     // Intentionally using the sync method because this only runs when the
@@ -135,9 +144,9 @@ function parseConfig(rootPath) {
     rootPath = resolvePathSync(rootPath);
 
     return {
-        "rootPath"    : rootPath,
-        "dynamicParam": dynamicParam,
-        "rootSuffix"  : rootSuffix,
-        "statCache"   : {}
+        "rootPath"      : rootPath,
+        "dynamicParams" : dynamicParams,
+        "rootSuffixes"  : rootSuffixes,
+        "statCache"     : {}
     };
 }

--- a/lib/middleware/dynamicPath.js
+++ b/lib/middleware/dynamicPath.js
@@ -25,44 +25,11 @@ exports = module.exports = function (options) {
         };
     }
 
-    // private fs.stat cache
-    var STAT_CACHE = {};
-
-    var rootPath   = path.normalize(options.rootPath),
-        dynamicKey = getDynamicKey(rootPath),
-        dynamicParam,
-        rootSuffix;
-
-    // str.match() in route config returns null if no matches or [":foo"]
-    if (dynamicKey) {
-        // key for the req.params must be stripped of the colon
-        dynamicParam = dynamicKey.substr(1);
-
-        // if the parameter is not the last token in the rootPath
-        // (e.g., '/foo/:version/bar/')
-        if (path.basename(rootPath).indexOf(dynamicKey) === -1) {
-            // rootSuffix must be stored for use in getDynamicRoot
-            rootSuffix = rootPath.substr(rootPath.indexOf(dynamicKey) + dynamicKey.length);
-        }
-
-        // remove key + suffix from rootPath used in initial realpathSync
-        rootPath = rootPath.substring(0, rootPath.indexOf(dynamicKey));
-    }
-
-    // Intentionally using the sync method because this only runs when the
-    // middleware is initialized, and we want it to throw if there's an error.
-    rootPath = resolvePathSync(rootPath);
-
-    return function dynamicPathMiddleware(req, res, next) {
+    function dynamicPathMiddleware(req, res, next) {
         // on the off chance this middleware runs twice
         if (!res.locals.rootPath) {
             // supply subsequent middleware with the res.locals.rootPath property
-            getDynamicRoot(req.params, {
-                "rootPath"    : rootPath,
-                "dynamicParam": dynamicParam,
-                "rootSuffix"  : rootSuffix,
-                "statCache"   : STAT_CACHE
-            }, function (err, resolvedRootPath) {
+            getDynamicRoot(req.params, dynamicPathMiddleware.CONFIG, function (err, resolvedRootPath) {
                 if (err) {
                     next(new BadRequest('Unable to resolve path: ' + req.path));
                 } else {
@@ -73,7 +40,12 @@ exports = module.exports = function (options) {
         } else {
             next();
         }
-    };
+    }
+
+    // cache config object used in middleware
+    dynamicPathMiddleware.CONFIG = parseConfig(options.rootPath);
+
+    return dynamicPathMiddleware;
 };
 
 function getDynamicRoot(params, opts, cb) {
@@ -121,4 +93,51 @@ function getDynamicKey(rootPath) {
     // route parameter matches ":foo" of "/:foo/bar/"
     var paramRegex = /:\w+/;
     return paramRegex.test(rootPath) && rootPath.match(paramRegex)[0];
+}
+
+/**
+Create a config object for use in dynamicPathMiddleware.
+
+@method parseConfig
+@param {String} rootPatha
+@return {Object} config
+    @property {String} config.rootPath
+    @property {String} config.dynamicParam
+    @property {String} config.rootSuffix
+    @property {String} config.statCache
+@private
+**/
+function parseConfig(rootPath) {
+    rootPath = path.normalize(rootPath);
+
+    var dynamicKey = getDynamicKey(rootPath),
+        dynamicParam,
+        rootSuffix;
+
+    // str.match() in route config returns null if no matches or [":foo"]
+    if (dynamicKey) {
+        // key for the req.params must be stripped of the colon
+        dynamicParam = dynamicKey.substr(1);
+
+        // if the parameter is not the last token in the rootPath
+        // (e.g., '/foo/:version/bar/')
+        if (path.basename(rootPath).indexOf(dynamicKey) === -1) {
+            // rootSuffix must be stored for use in getDynamicRoot
+            rootSuffix = rootPath.substr(rootPath.indexOf(dynamicKey) + dynamicKey.length);
+        }
+
+        // remove key + suffix from rootPath used in initial realpathSync
+        rootPath = rootPath.substring(0, rootPath.indexOf(dynamicKey));
+    }
+
+    // Intentionally using the sync method because this only runs when the
+    // middleware is initialized, and we want it to throw if there's an error.
+    rootPath = resolvePathSync(rootPath);
+
+    return {
+        "rootPath"    : rootPath,
+        "dynamicParam": dynamicParam,
+        "rootSuffix"  : rootSuffix,
+        "statCache"   : {}
+    };
 }

--- a/test/server.js
+++ b/test/server.js
@@ -572,6 +572,46 @@ describe('combohandler', function () {
             body: "Bad request. Unable to resolve path: /dynamic/deadbeef",
             status: 400
         }));
+
+        describe("with multiple parameters", function () {
+            before(function () {
+                app.get("/dynamic/:major/:minor",
+                    combo.combine({ rootPath: FIXTURES_DIR + "/dynamic/:major/:minor" }),
+                combo.respond);
+
+                app.get("/:major/:minor/rootpath-omit",
+                    combo.combine({ rootPath: FIXTURES_DIR + "/dynamic/:major/static" }),
+                combo.respond);
+
+                app.get("/omit-route/:major",
+                    combo.combine({ rootPath: FIXTURES_DIR + "/dynamic/:major/:minor" }),
+                combo.respond);
+
+                app.get("/:major/separated/by/:minor",
+                    combo.combine({ rootPath: FIXTURES_DIR + "/:major/:minor/static" }),
+                combo.respond);
+            });
+
+            it("should resolve path", assertResponds({
+                path: "/dynamic/decafbad/static?c.js&d.js",
+                body: "c();\n\nd();\n"
+            }));
+
+            it("should resolve root path that omits route parameter", assertResponds({
+                path: "/decafbad/latest/rootpath-omit?c.js&d.js",
+                body: "c();\n\nd();\n"
+            }));
+
+            it("should resolve route that has more parameters than root path", assertResponds({
+                path: "/omit-route/decafbad?a.js&static/c.js",
+                body: "a();\n\nc();\n"
+            }));
+
+            it("should resolve route that has separated parameters", assertResponds({
+                path: "/dynamic/separated/by/decafbad?c.js&d.js",
+                body: "c();\n\nd();\n"
+            }));
+        });
     });
 
     // -- Complex Integration --------------------------------------------------


### PR DESCRIPTION
Turns out, this is useful, and a silly limitation of the original middleware.
