### PR TITLE
Allow unresolved rootpath symlinks

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -14,6 +14,7 @@ var knownOpts = {
     "pids": path,
     "port": Number,
     "restart": Boolean,
+    "resolveSymlinks": Boolean,
     "root": [String, Array],
     "rootsFile": path,
     "server": path,
@@ -26,6 +27,7 @@ var knownOpts = {
 };
 
 var shortHands = {
+    "--no-resolve-symlinks": ["--no-resolveSymlinks"],
     "h": ["--help"],
     "v": ["--version"],
     "a": ["--server"],
@@ -65,6 +67,9 @@ exports = module.exports = {
         msg.push("  -m, --maxAge      'Cache-Control' and 'Expires' value, in seconds.  [31536000]");
         msg.push("                    Set this to `0` to expire immediately, `null` to omit these");
         msg.push("                    headers entirely.");
+        msg.push("");
+        msg.push("  --no-resolve-symlinks");
+        msg.push("      If passed, rootPaths that are symlinks will not be resolved (the default).");
         msg.push("");
         msg.push("Cluster Options:");
         msg.push("  --cluster         Enable clustering of server across multiple processes.");

--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -44,7 +44,7 @@ exports.combine = function (config) {
         // Intentionally using the sync method because this only runs when the
         // middleware is initialized, and we want it to throw if there's an
         // error.
-        rootPathResolved = resolvePathSync(config.rootPath);
+        rootPathResolved = resolvePathSync(config.rootPath, config.resolveSymlinks);
     }
 
     function combineMiddleware(req, res, next) {

--- a/lib/middleware/dynamicPath.js
+++ b/lib/middleware/dynamicPath.js
@@ -137,7 +137,7 @@ function parseConfig(rootPath) {
                 rootSuffixes.unshift('');
             }
 
-            // remove key + suffix from rootPath used in initial realpathSync
+            // remove key + suffix from rootPath used in initial resolvePathSync
             rootPath = rootPath.substring(0, rootPath.lastIndexOf(dynamicKey));
         });
     }

--- a/lib/middleware/dynamicPath.js
+++ b/lib/middleware/dynamicPath.js
@@ -43,7 +43,7 @@ exports = module.exports = function (options) {
     }
 
     // cache config object used in middleware
-    dynamicPathMiddleware.CONFIG = parseConfig(options.rootPath);
+    dynamicPathMiddleware.CONFIG = parseConfig(options.rootPath, options.resolveSymlinks);
 
     return dynamicPathMiddleware;
 };
@@ -102,7 +102,8 @@ function getDynamicKeys(rootPath) {
 Create a config object for use in dynamicPathMiddleware.
 
 @method parseConfig
-@param {String} rootPatha
+@param {String} rootPath
+@param {Boolean} resolveSymlinks
 @return {Object} config
     @property {String} config.rootPath
     @property {String} config.dynamicParam
@@ -110,7 +111,7 @@ Create a config object for use in dynamicPathMiddleware.
     @property {String} config.statCache
 @private
 **/
-function parseConfig(rootPath) {
+function parseConfig(rootPath, resolveSymlinks) {
     rootPath = path.normalize(rootPath);
 
     var dynamicKeys = getDynamicKeys(rootPath);
@@ -144,7 +145,7 @@ function parseConfig(rootPath) {
 
     // Intentionally using the sync method because this only runs when the
     // middleware is initialized, and we want it to throw if there's an error.
-    rootPath = resolvePathSync(rootPath);
+    rootPath = resolvePathSync(rootPath, resolveSymlinks);
 
     return {
         "rootPath"      : rootPath,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,8 +44,11 @@ function memoize(source) {
 }
 
 function resolvePathSync(rootPath) {
+    // Turns out fs.realpathSync was always defaulting empty strings to cwd().
+    rootPath = rootPath || process.cwd();
     // Intentionally using the sync method because this only runs when the
     // middleware is initialized, and we want it to throw if there's an error.
+    fs.statSync(rootPath);
     // The resulting rootPath should always have a trailing slash.
-    return path.normalize(fs.realpathSync(rootPath || '') + path.sep);
+    return path.normalize(rootPath + path.sep);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,12 +43,18 @@ function memoize(source) {
     };
 }
 
-function resolvePathSync(rootPath) {
-    // Turns out fs.realpathSync was always defaulting empty strings to cwd().
+function resolvePathSync(rootPath, resolveSymlinks) {
+    // Turns out fs.realpathSync always defaults empty strings to cwd().
     rootPath = rootPath || process.cwd();
+
     // Intentionally using the sync method because this only runs when the
     // middleware is initialized, and we want it to throw if there's an error.
-    fs.statSync(rootPath);
+    if (resolveSymlinks !== false) {
+        rootPath = fs.realpathSync(rootPath);
+    } else {
+        fs.statSync(rootPath);
+    }
+
     // The resulting rootPath should always have a trailing slash.
     return path.normalize(rootPath + path.sep);
 }

--- a/test/server.js
+++ b/test/server.js
@@ -741,7 +741,7 @@ describe('combohandler', function () {
 
                     app.get("/c/:version/fs-shallow", combined, function (req, res, next) {
                         var rootPath = res.locals.rootPath;
-                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/base/'));
+                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/versioned/shallower/base/'));
 
                         var relativePath = res.locals.relativePaths[0];
                         relativePath.should.equal('js/a.js');
@@ -754,20 +754,19 @@ describe('combohandler', function () {
                     }, combo.respond);
 
                     app.get("/c/:version/ln-shallow", combined, function (req, res, next) {
-                        var rootPath = res.locals.rootPath;
-                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/base/'));
-
                         var relativePath = res.locals.relativePaths[0];
                         relativePath.should.equal('css/urls/simple.css');
 
                         // console.error(res.body);
-                        res.body.should.equal(TEMPLATE_SIMPLE.replace(/__ROOT__/g, '/base/'));
+                        var expected = TEMPLATE_SIMPLE
+                                        .replace(/__ROOT__/g, '/versioned/shallower/base/');
+                        res.body.should.equal(expected);
 
                         next();
                     }, combo.respond);
                 });
 
-                it("should resolve files from realpath in filesystem", assertResponds({
+                it("should resolve files from symlink in filesystem", assertResponds({
                     path: "/c/cafebabe/fs-shallow?js/a.js&js/b.js"
                 }));
 
@@ -786,24 +785,25 @@ describe('combohandler', function () {
 
                     app.get("/c/:version/fs-deeper", combined, function (req, res, next) {
                         var rootPath = res.locals.rootPath;
-                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/versioned/deeper/base/'));
+                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/deep-link/'));
 
                         var relativePath = res.locals.relativePaths[0];
                         relativePath.should.equal('js/a.js');
 
-                        next();
+                        fs.realpath(path.join(rootPath, relativePath), function (err, resolved) {
+                            assert.ifError(err);
+                            resolved.should.equal(path.join(COMPLEX_ROOT, '/versioned/deeper/base/', relativePath));
+                            next();
+                        });
                     }, combo.respond);
 
                     app.get("/c/:version/ln-deeper", combined, function (req, res, next) {
-                        var rootPath = res.locals.rootPath;
-                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/versioned/deeper/base/'));
-
                         var relativePath = res.locals.relativePaths[0];
                         relativePath.should.equal('css/urls/simple.css');
 
                         // console.error(res.body);
                         var expected = TEMPLATE_SIMPLE
-                                        .replace(/__ROOT__/g, '/versioned/deeper/base/');
+                                        .replace(/__ROOT__/g, '/deep-link/');
                         res.body.should.equal(expected);
 
                         next();

--- a/test/server.js
+++ b/test/server.js
@@ -674,6 +674,42 @@ describe('combohandler', function () {
         ].join('\n');
         var SIMPLE_RAW = SIMPLE_IMPORTS_RAW + SIMPLE_URLS_RAW;
 
+        function dynamicFiletree(opts) {
+            var expectedRelativePath = opts.relativePath || "js/a.js";
+            var expectedResolvedPath = path.join(COMPLEX_ROOT, opts.realPath, expectedRelativePath);
+            var expectedRootPath     = path.join(COMPLEX_ROOT, opts.rootPath);
+
+            return function (req, res, next) {
+                var rootPath = res.locals.rootPath;
+                rootPath.should.equal(expectedRootPath);
+
+                var relativePath = res.locals.relativePaths[0];
+                relativePath.should.equal(expectedRelativePath);
+
+                fs.realpath(path.join(rootPath, relativePath), function (err, resolved) {
+                    assert.ifError(err);
+                    resolved.should.equal(expectedResolvedPath);
+                    next();
+                });
+            };
+        }
+
+        function dynamicSymlinks(opts) {
+            var expectedTemplateFile = opts.template || TEMPLATE_SIMPLE;
+            var expectedRelativePath = opts.relativePath || "css/urls/simple.css";
+            var expectedResolvedBody = expectedTemplateFile.replace(/__ROOT__/g, opts.rootPath);
+
+            return function (req, res, next) {
+                var relativePath = res.locals.relativePaths[0];
+                relativePath.should.equal(expectedRelativePath);
+
+                // console.error(res.body);
+                res.body.should.equal(expectedResolvedBody);
+
+                next();
+            };
+        }
+
         describe("route with fully-qualified dynamic path", function () {
             before(function () {
                 var combined = combo.combine({
@@ -681,40 +717,21 @@ describe('combohandler', function () {
                     rootPath: COMPLEX_ROOT + '/versioned/:version/base/'
                 });
 
-                app.get("/c/:version/fs-fq", combined, function (req, res, next) {
-                    var rootPath = res.locals.rootPath;
-                    rootPath.should.equal(path.join(COMPLEX_ROOT, '/versioned/deeper/base/'));
-                    next();
-                }, combo.respond);
+                app.get("/c/:version/fs-fq", combined, dynamicFiletree({
+                    realPath: "/versioned/deeper/base/",
+                    rootPath: "/versioned/deeper/base/"
+                }), combo.respond);
 
-                app.get("/c/:version/ln-fq", combined, function (req, res, next) {
-                    var rootPath = res.locals.rootPath;
-                    rootPath.should.equal(path.join(COMPLEX_ROOT, '/versioned/shallower/base/'));
+                app.get("/c/:version/ln-fq", combined, dynamicFiletree({
+                    realPath: "/base/",
+                    rootPath: "/versioned/shallower/base/"
+                }), combo.respond);
 
-                    var relativePath = res.locals.relativePaths[0];
-                    relativePath.should.equal('js/a.js');
-
-                    fs.realpath(path.join(rootPath, relativePath), function (err, resolved) {
-                        assert.ifError(err);
-                        resolved.should.equal(path.join(COMPLEX_ROOT, '/base/', relativePath));
-                        next();
-                    });
-                }, combo.respond);
-
-                app.get("/c/:version/fq-noimports", combined, function (req, res, next) {
-                    var rootPath = res.locals.rootPath;
-                    rootPath.should.equal(path.join(COMPLEX_ROOT, '/versioned/shallower/base/'));
-
-                    var relativePath = res.locals.relativePaths[0];
-                    relativePath.should.equal('css/urls/simple.css');
-
-                    // console.error(res.body);
-                    var expected = (SIMPLE_IMPORTS_RAW + TEMPLATE_URLS_SIMPLE)
-                                    .replace(/__ROOT__/g, '/versioned/shallower/base/');
-                    res.body.should.equal(expected);
-
-                    next();
-                }, combo.respond);
+                app.get("/c/:version/fq-noimports", combined, dynamicSymlinks({
+                    template: SIMPLE_IMPORTS_RAW + TEMPLATE_URLS_SIMPLE,
+                    realPath: "/versioned/shallower/base/",
+                    rootPath: "/versioned/shallower/base/"
+                }), combo.respond);
             });
 
             it("should read rootPath from filesystem directly", assertResponds({
@@ -732,91 +749,117 @@ describe('combohandler', function () {
 
         describe("route with one-sided dynamic path", function () {
             describe("and rootPath symlinked shallower", function () {
-                before(function () {
-                    var combined = combo.combine({
-                        rewriteImports: true,
-                        webRoot : COMPLEX_ROOT,
-                        rootPath: COMPLEX_ROOT + '/versioned/shallower/base/'
+                describe("when resolveSymlinks is true", function () {
+                    before(function () {
+                        var resolved = combo.combine({
+                            rewriteImports: true,
+                            webRoot : COMPLEX_ROOT,
+                            rootPath: COMPLEX_ROOT + '/versioned/shallower/base/'
+                        });
+
+                        app.get("/r/:version/fs-shallow", resolved, dynamicFiletree({
+                            realPath: "/base/",
+                            rootPath: "/base/"
+                        }), combo.respond);
+
+                        app.get("/r/:version/ln-shallow", resolved, dynamicSymlinks({
+                            rootPath: "/base/"
+                        }), combo.respond);
                     });
 
-                    app.get("/c/:version/fs-shallow", combined, function (req, res, next) {
-                        var rootPath = res.locals.rootPath;
-                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/versioned/shallower/base/'));
+                    it("should resolve files from realpath in filesystem", assertResponds({
+                        path: "/r/cafebabe/fs-shallow?js/a.js&js/b.js"
+                    }));
 
-                        var relativePath = res.locals.relativePaths[0];
-                        relativePath.should.equal('js/a.js');
-
-                        fs.realpath(path.join(rootPath, relativePath), function (err, resolved) {
-                            assert.ifError(err);
-                            resolved.should.equal(path.join(COMPLEX_ROOT, '/base/', relativePath));
-                            next();
-                        });
-                    }, combo.respond);
-
-                    app.get("/c/:version/ln-shallow", combined, function (req, res, next) {
-                        var relativePath = res.locals.relativePaths[0];
-                        relativePath.should.equal('css/urls/simple.css');
-
-                        // console.error(res.body);
-                        var expected = TEMPLATE_SIMPLE
-                                        .replace(/__ROOT__/g, '/versioned/shallower/base/');
-                        res.body.should.equal(expected);
-
-                        next();
-                    }, combo.respond);
+                    it("should rewrite url() through symlink", assertResponds({
+                        path: "/r/cafebabe/ln-shallow?css/urls/simple.css"
+                    }));
                 });
 
-                it("should resolve files from symlink in filesystem", assertResponds({
-                    path: "/c/cafebabe/fs-shallow?js/a.js&js/b.js"
-                }));
+                describe("when resolveSymlinks is false", function () {
+                    before(function () {
+                        var symlinkd = combo.combine({
+                            rewriteImports: true,
+                            resolveSymlinks: false,
+                            webRoot : COMPLEX_ROOT,
+                            rootPath: COMPLEX_ROOT + '/versioned/shallower/base/'
+                        });
 
-                it("should rewrite url() through symlink", assertResponds({
-                    path: "/c/cafebabe/ln-shallow?css/urls/simple.css"
-                }));
+                        app.get("/s/:version/fs-shallow", symlinkd, dynamicFiletree({
+                            realPath: "/base/",
+                            rootPath: "/versioned/shallower/base/"
+                        }), combo.respond);
+
+                        app.get("/s/:version/ln-shallow", symlinkd, dynamicSymlinks({
+                            rootPath: "/versioned/shallower/base/"
+                        }), combo.respond);
+                    });
+
+                    it("should resolve files from symlink in filesystem", assertResponds({
+                        path: "/s/cafebabe/fs-shallow?js/a.js&js/b.js"
+                    }));
+
+                    it("should rewrite url() using symlink", assertResponds({
+                        path: "/s/cafebabe/ln-shallow?css/urls/simple.css"
+                    }));
+                });
             });
 
             describe("and rootPath symlinked deeper", function () {
-                before(function () {
-                    var combined = combo.combine({
-                        rewriteImports: true,
-                        webRoot : COMPLEX_ROOT,
-                        rootPath: COMPLEX_ROOT + '/deep-link/'
+                describe("when resolveSymlinks is true", function () {
+                    before(function () {
+                        var resolved = combo.combine({
+                            rewriteImports: true,
+                            webRoot : COMPLEX_ROOT,
+                            rootPath: COMPLEX_ROOT + '/deep-link/'
+                        });
+
+                        app.get("/r/:version/fs-deeper", resolved, dynamicFiletree({
+                            realPath: "/versioned/deeper/base/",
+                            rootPath: "/versioned/deeper/base/"
+                        }), combo.respond);
+
+                        app.get("/r/:version/ln-deeper", resolved, dynamicSymlinks({
+                            rootPath: "/versioned/deeper/base/"
+                        }), combo.respond);
                     });
 
-                    app.get("/c/:version/fs-deeper", combined, function (req, res, next) {
-                        var rootPath = res.locals.rootPath;
-                        rootPath.should.equal(path.join(COMPLEX_ROOT, '/deep-link/'));
+                    it("should read rootPath from filesystem directly", assertResponds({
+                        path: "/r/cafebabe/fs-deeper?js/a.js&js/b.js"
+                    }));
 
-                        var relativePath = res.locals.relativePaths[0];
-                        relativePath.should.equal('js/a.js');
-
-                        fs.realpath(path.join(rootPath, relativePath), function (err, resolved) {
-                            assert.ifError(err);
-                            resolved.should.equal(path.join(COMPLEX_ROOT, '/versioned/deeper/base/', relativePath));
-                            next();
-                        });
-                    }, combo.respond);
-
-                    app.get("/c/:version/ln-deeper", combined, function (req, res, next) {
-                        var relativePath = res.locals.relativePaths[0];
-                        relativePath.should.equal('css/urls/simple.css');
-
-                        // console.error(res.body);
-                        var expected = TEMPLATE_SIMPLE
-                                        .replace(/__ROOT__/g, '/deep-link/');
-                        res.body.should.equal(expected);
-
-                        next();
-                    }, combo.respond);
+                    it("should *still* rewrite url() through symlink", assertResponds({
+                        path: "/r/cafebabe/ln-deeper?css/urls/simple.css"
+                    }));
                 });
 
-                it("should read rootPath from filesystem directly", assertResponds({
-                    path: "/c/cafebabe/fs-deeper?js/a.js&js/b.js"
-                }));
+                describe("when resolveSymlinks is false", function () {
+                    before(function () {
+                        var symlinkd = combo.combine({
+                            rewriteImports: true,
+                            resolveSymlinks: false,
+                            webRoot : COMPLEX_ROOT,
+                            rootPath: COMPLEX_ROOT + '/deep-link/'
+                        });
 
-                it("should *still* rewrite url() through symlink", assertResponds({
-                    path: "/c/cafebabe/ln-deeper?css/urls/simple.css"
-                }));
+                        app.get("/s/:version/fs-deeper", symlinkd, dynamicFiletree({
+                            realPath: "/versioned/deeper/base/",
+                            rootPath: "/deep-link/"
+                        }), combo.respond);
+
+                        app.get("/s/:version/ln-deeper", symlinkd, dynamicSymlinks({
+                            rootPath: "/deep-link/"
+                        }), combo.respond);
+                    });
+
+                    it("should read rootPath from symlink in filesystem", assertResponds({
+                        path: "/s/cafebabe/fs-deeper?js/a.js&js/b.js"
+                    }));
+
+                    it("should *still* rewrite url() using symlink", assertResponds({
+                        path: "/s/cafebabe/ln-deeper?css/urls/simple.css"
+                    }));
+                });
             });
         });
     });


### PR DESCRIPTION
Occasionally, I want to use a symlink as the rootPath of a route, but I need the symlink to be retargeted from time to time (say, when code ships). As this is a potentially risky practice, as well as backward-incompatible, it is strictly opt-in.
