### PR TITLE
Support for windows. Support for baseUrl config option.

### DIFF
--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -34,7 +34,7 @@ exports.combine = function (config) {
         maxAge = 31536000; // one year in seconds
     }
 
-    if (config.basePath || config.webRoot) {
+    if (config.basePath || config.webRoot || config.baseUrl) {
         callbacks.push(exports.middleware.cssUrls(config));
     }
 

--- a/lib/middleware/cssUrls.js
+++ b/lib/middleware/cssUrls.js
@@ -9,7 +9,7 @@ var memoize = require('../utils').memoize;
 var RX_URL = /(?:\@import)?\s*url\(\s*(['"]?)(\S+)\1\s*\)/g;
 var RX_IMPORT = /\@import\s*(?:url\(\s*)?(['"]?)(\S+)\1(?:\s*\))?[^;'"]*;/g;
 
-var replacer = function replacer(basePath, relativePath, importsEnabled) {
+var replacer = function replacer(basePath, baseUrl, relativePath, importsEnabled) {
     return function (substr, quote, match) {
         if (!substringEligible(substr, match, importsEnabled)) {
             return substr;
@@ -19,6 +19,12 @@ var replacer = function replacer(basePath, relativePath, importsEnabled) {
             fileDirName  = path.dirname(fileBasePath),
             absolutePath = path.resolve(fileDirName, match);
 
+        if (absolutePath[1] === ':') {
+            absolutePath = absolutePath.substring((baseUrl && 3) || 2).replace(/\\/g, '/');
+        }
+        if (baseUrl) {
+            absolutePath = baseUrl + absolutePath;
+        }
         return substr.replace(match, absolutePath);
     };
 };
@@ -58,7 +64,12 @@ exports = module.exports = function (options) {
     var importsEnabled = (true === options.rewriteImports);
     var basePath = options.basePath;
     var webRoot = options.webRoot;
-    var enabled = !!(basePath || webRoot);
+    var baseUrl = options.baseUrl;
+    var enabled = !!(basePath || webRoot || baseUrl);
+
+    if (baseUrl.indexOf('/', baseUrl.length - 1) < 0) {
+        baseUrl += '/';
+    }
 
     return function cssUrlsMiddleware(req, res, next) {
         var relativePaths = res.locals.relativePaths;
@@ -66,6 +77,7 @@ exports = module.exports = function (options) {
 
         if (enabled && !!(relativePaths && bodyContents) && isCSS(res)) {
             var opts = {
+                baseUrl: baseUrl,
                 "basePath": basePath,
                 "importsEnabled": importsEnabled
             };
@@ -94,8 +106,9 @@ exports = module.exports = function (options) {
 exports.rewrite = function rewriteCSSURLs(data, relativePath, opts) {
     var basePath = opts.basePath;
     var importsEnabled = opts.importsEnabled;
+    var baseUrl = opts.baseUrl;
 
-    var replaceCallback = replacer(basePath, relativePath, importsEnabled);
+    var replaceCallback = replacer(basePath, baseUrl, relativePath, importsEnabled);
 
     if (importsEnabled) {
         data = data.replace(RX_IMPORT, replaceCallback);


### PR DESCRIPTION
Normalizing the path on Windows prepends C: and replaces / with \ thus
breaking otherwise valid relative urls. This commit fixes it.
In addition, it adds support for a new config option - baseUrl.
Motivation - the static content is served by jetty running at
http://localhost:8080, but the combohandler is served by node.js at
http://localhost:8000. Before this change, such scenario was not
supported. Now it is.
