### PR TITLE
Compatability with express 4.0

### DIFF
--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -1,5 +1,6 @@
 var fs   = require('fs'),
     path = require('path'),
+    utils = require('./utils'),
 
     // exported to allow instanceof checks
     BadRequest = exports.BadRequest = require('./error/bad-request'),
@@ -15,7 +16,7 @@ var fs   = require('fs'),
         '.xml' : 'application/xml'
     };
 
-var resolvePathSync = require('./utils').resolvePathSync;
+var resolvePathSync = utils.resolvePathSync;
 
 // -- Exported Methods ---------------------------------------------------------
 exports.combine = function (config) {
@@ -74,7 +75,7 @@ exports.combine = function (config) {
             res.contentType(type);
 
             // provide metadata to subsequent middleware via res.locals
-            res.locals({
+            utils.mix(res.locals, {
                 rootPath: rootPath, // ensures this always has a value
                 bodyContents: body,
                 relativePaths: query


### PR DESCRIPTION
As of express 4, res.locals is no longer a function, so we need to treat it as a plain JS object.
