### PR TITLE
Express 4.x

### DIFF
--- a/lib/combohandler.js
+++ b/lib/combohandler.js
@@ -176,7 +176,7 @@ exports.errorHandler = function (options) {
                 res.header('Pragma', 'no-cache');
             }
 
-            res.send(400, 'Bad request. ' + err.message);
+            res.status(400).send('Bad request. ' + err.message);
         } else {
             next(err);
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,41 +1,33 @@
 var combo   = require('./combohandler'),
     merge   = require('./utils').merge,
+    logger  = require('morgan'),
+    errors  = require('errorhandler'),
     express = require('express');
 
 module.exports = function (config, baseApp) {
     var app   = baseApp || express(),
+        env   = process.env.NODE_ENV || 'development',
         roots = (config && config.roots) || {},
         route;
 
     if (!baseApp) {
-        app.configure('development', function () {
-            app.use(express.logger());
-            app.use(express.errorHandler({
-                dumpExceptions: true,
-                showStack     : true
-            }));
-        });
-
-        app.configure('test', function () {
-            app.use(express.errorHandler({
-                dumpExceptions: true,
-                showStack     : true
-            }));
-        });
-
-        app.configure('production', function () {
-            app.use(express.errorHandler());
-        });
-
-        app.use(app.router);
-
-        app.use(combo.errorHandler());
+        if (env === 'development') {
+            app.use(logger());
+            app.use(errors());
+        } else if (env === 'test') {
+            app.use(errors());
+        }
     }
 
     /*jshint forin:false */
     for (route in roots) {
         // pass along all of config, overwriting rootPath
         app.get(route, combo.combine(merge(config, {rootPath: roots[route]})), combo.respond);
+    }
+
+    if (!baseApp) {
+        // Express 4.x removes app.router, running all middleware in order
+        app.use(combo.errorHandler());
     }
 
     return app;

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,7 @@ module.exports = function (config, baseApp) {
 
     if (!baseApp) {
         if (env === 'development') {
-            app.use(logger());
+            app.use(logger('combined'));
             app.use(errors());
         } else if (env === 'test') {
             app.use(errors());

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "dependencies": {
         "mkdirp" : "0.5.0",
         "nopt"   : "3.0.0",
-        "express": "3.4.0",
+        "express": "4.4.1",
+        "morgan" : "1.1.1",
+        "errorhandler": "1.0.2",
         "URIjs"  : "1.13.2"
     },
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dependencies": {
         "mkdirp" : "0.5.0",
         "nopt"   : "3.0.0",
-        "express": "4.4.1",
+        "express": "4.4.2",
         "morgan" : "1.1.1",
         "errorhandler": "1.0.2",
         "URIjs"  : "1.13.2"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "nopt"   : "3.0.1",
         "express": "4.4.2",
         "morgan" : "1.1.1",
-        "errorhandler": "1.0.2",
+        "errorhandler": "1.1.1",
         "URIjs"  : "1.13.2"
     },
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dependencies": {
         "mkdirp" : "0.5.0",
         "nopt"   : "3.0.1",
-        "express": "4.4.2",
+        "express": "4.7.3",
         "morgan" : "1.2.2",
         "errorhandler": "1.1.1",
         "URIjs"  : "1.13.2"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "mkdirp" : "0.5.0",
         "nopt"   : "3.0.1",
         "express": "4.4.2",
-        "morgan" : "1.1.1",
+        "morgan" : "1.2.2",
         "errorhandler": "1.1.1",
         "URIjs"  : "1.13.2"
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 
     "dependencies": {
         "mkdirp" : "0.5.0",
-        "nopt"   : "3.0.0",
+        "nopt"   : "3.0.1",
         "express": "4.4.2",
         "morgan" : "1.1.1",
         "errorhandler": "1.0.2",


### PR DESCRIPTION
Increasingly, I feel that `lib/server` and the CLI executable should be separated from the rest of the library (`combohandler-server`?), as it is itself just a consumer of the middleware. It's burdening those whole only ever use the library as middleware with all of express, etc.

The changes herein are largely explained by the [Migrating from 3.x to 4.x](https://github.com/visionmedia/express/wiki/Migrating-from-3.x-to-4.x) wiki.
